### PR TITLE
feat: add student info tooltip on name hover

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1552,10 +1552,6 @@ body.modal-open { overflow: hidden; }
 .history-name-item.is-hovered,
 .result-name.is-text.is-hovered {
     color: rgba(78, 205, 255, 0.95);
-    text-decoration: underline;
-    text-decoration-color: rgba(78, 205, 255, 0.4);
-    text-decoration-thickness: 2px;
-    text-underline-offset: 2px;
 }
 
 .history-name-item {

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1523,7 +1523,7 @@ body.modal-open { overflow: hidden; }
 }
 
 .student-info-tooltip-name {
-    font-size: 1rem;
+    font-size: 1.1rem;
     font-weight: 600;
     color: #fff;
     line-height: 1.3;
@@ -1532,15 +1532,22 @@ body.modal-open { overflow: hidden; }
 .student-info-tooltip-meta {
     display: flex;
     flex-direction: column;
-    gap: 0.35rem;
-    font-size: 0.82rem;
+    gap: 0.4rem;
+    font-size: 0.9rem;
     color: rgba(221, 230, 255, 0.85);
     line-height: 1.4;
+}
+
+.student-info-tooltip-id {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: rgba(78, 205, 255, 0.95);
 }
 
 .student-info-tooltip-id::before {
     content: "ID: ";
     color: rgba(221, 230, 255, 0.6);
+    font-weight: 500;
 }
 
 .student-info-tooltip-group::before {

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1549,7 +1549,8 @@ body.modal-open { overflow: hidden; }
 }
 
 .result-name-item.is-hovered,
-.history-name-item.is-hovered {
+.history-name-item.is-hovered,
+.result-name.is-text.is-hovered {
     color: rgba(78, 205, 255, 0.95);
     text-decoration: underline;
     text-decoration-color: rgba(78, 205, 255, 0.4);
@@ -1558,5 +1559,10 @@ body.modal-open { overflow: hidden; }
 }
 
 .history-name-item {
+    transition: color 0.15s ease, text-decoration 0.15s ease;
+}
+
+.result-name.is-text {
+    cursor: pointer;
     transition: color 0.15s ease, text-decoration 0.15s ease;
 }

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1493,3 +1493,70 @@ body.modal-open { overflow: hidden; }
         font-size: 0.85rem;
     }
 }
+
+.student-info-tooltip {
+    position: fixed;
+    z-index: 9999;
+    background: rgba(18, 22, 36, 0.98);
+    backdrop-filter: blur(20px);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 12px;
+    box-shadow:
+        0 12px 32px rgba(0, 0, 0, 0.45),
+        0 0 0 1px rgba(255, 255, 255, 0.08) inset;
+    padding: 0.85rem 1.1rem;
+    min-width: 140px;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease-out;
+    transform: translateY(-4px);
+}
+
+.student-info-tooltip:not([hidden]) {
+    opacity: 1;
+}
+
+.student-info-tooltip-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.student-info-tooltip-name {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #fff;
+    line-height: 1.3;
+}
+
+.student-info-tooltip-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-size: 0.82rem;
+    color: rgba(221, 230, 255, 0.85);
+    line-height: 1.4;
+}
+
+.student-info-tooltip-id::before {
+    content: "ID: ";
+    color: rgba(221, 230, 255, 0.6);
+}
+
+.student-info-tooltip-group::before {
+    content: "小组: ";
+    color: rgba(221, 230, 255, 0.6);
+}
+
+.result-name-item.is-hovered,
+.history-name-item.is-hovered {
+    color: rgba(78, 205, 255, 0.95);
+    text-decoration: underline;
+    text-decoration-color: rgba(78, 205, 255, 0.4);
+    text-decoration-thickness: 2px;
+    text-underline-offset: 2px;
+}
+
+.history-name-item {
+    transition: color 0.15s ease, text-decoration 0.15s ease;
+}

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -4791,17 +4791,28 @@ function initStudentInfoTooltip() {
 
     function handleResultNameHover(event) {
         const target = event.target;
-        if (!target.classList.contains("result-name-item")) return;
 
-        const name = target.textContent.trim();
-        const student = findStudentByName(name);
-        if (!student) return;
+        if (target.classList.contains("result-name-item")) {
+            const name = target.textContent.trim();
+            const student = findStudentByName(name);
+            if (!student) return;
+            showTooltip(target, student, event.clientX, event.clientY);
+            return;
+        }
 
-        showTooltip(target, student, event.clientX, event.clientY);
+        if (target.id === "result-name" && target.classList.contains("is-text")) {
+            const name = target.textContent.trim();
+            if (!name || name === "--") return;
+            const student = findStudentByName(name);
+            if (!student) return;
+            showTooltip(target, student, event.clientX, event.clientY);
+        }
     }
 
     function handleResultNameLeave(event) {
-        if (event.target.classList.contains("result-name-item")) {
+        const target = event.target;
+        if (target.classList.contains("result-name-item") ||
+            (target.id === "result-name" && target.classList.contains("is-text"))) {
             hideTooltip();
         }
     }

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -4761,8 +4761,13 @@ function initStudentInfoTooltip() {
             tooltip.hidden = false;
 
             const tooltipRect = tooltip.getBoundingClientRect();
+            const targetRect = target.getBoundingClientRect();
             const viewportWidth = window.innerWidth;
             const viewportHeight = window.innerHeight;
+
+            const maxDistance = 250;
+            const targetCenterX = targetRect.left + targetRect.width / 2;
+            const targetCenterY = targetRect.top + targetRect.height / 2;
 
             let left = x + 12;
             let top = y + 12;
@@ -4774,8 +4779,23 @@ function initStudentInfoTooltip() {
                 top = y - tooltipRect.height - 12;
             }
 
-            tooltip.style.left = `${Math.max(8, left)}px`;
-            tooltip.style.top = `${Math.max(8, top)}px`;
+            const tooltipCenterX = left + tooltipRect.width / 2;
+            const tooltipCenterY = top + tooltipRect.height / 2;
+            const distance = Math.sqrt(
+                Math.pow(tooltipCenterX - targetCenterX, 2) +
+                Math.pow(tooltipCenterY - targetCenterY, 2)
+            );
+
+            if (distance > maxDistance) {
+                const angle = Math.atan2(tooltipCenterY - targetCenterY, tooltipCenterX - targetCenterX);
+                const constrainedX = targetCenterX + Math.cos(angle) * maxDistance;
+                const constrainedY = targetCenterY + Math.sin(angle) * maxDistance;
+                left = constrainedX - tooltipRect.width / 2;
+                top = constrainedY - tooltipRect.height / 2;
+            }
+
+            tooltip.style.left = `${Math.max(8, Math.min(viewportWidth - tooltipRect.width - 8, left))}px`;
+            tooltip.style.top = `${Math.max(8, Math.min(viewportHeight - tooltipRect.height - 8, top))}px`;
         }, 100);
     }
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -186,6 +186,16 @@
     <div class="draw-mode-tooltip-arrow"></div>
 </div>
 
+<div id="student-info-tooltip" class="student-info-tooltip" hidden>
+    <div class="student-info-tooltip-content">
+        <div class="student-info-tooltip-name"></div>
+        <div class="student-info-tooltip-meta">
+            <span class="student-info-tooltip-id"></span>
+            <span class="student-info-tooltip-group"></span>
+        </div>
+    </div>
+</div>
+
 <button id="back-to-top" class="back-to-top" aria-label="回到顶部">
     <svg viewBox="0 0 16 16" fill="none">
         <path d="M8 4l-6 6h12L8 4z" fill="currentColor"/>


### PR DESCRIPTION
Add tooltip that displays student ID and group when hovering over student names in result-name-shell and history-entry-names. Features quick display with minimal delay for rapid information lookup, consistent UI styling, and name highlighting on hover.